### PR TITLE
Avoid more errors when `config.APP` is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 /* global module, require */
 'use strict';
-var fs = require('fs');
 
 module.exports = {
   name: 'ember-cli-app-version',
   config: function(env, baseConfig) {
     var config = this._super.config.apply(this, arguments);
+
+    if (!baseConfig.APP) {
+      return config;
+    }
 
     baseConfig.APP.name = this.project.pkg.name;
 


### PR DESCRIPTION
Continuing work in https://github.com/ember-cli/ember-cli-app-version/commit/f3c2e1a8e8c52b0e9469fa8c089f57d68958332a, this change ensures that APP exists before assigning properties to in the addon's `config` hook.

@rwjblue here's another CI fix for Ember CLI