### PR TITLE
Improved regex, added new flags to helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This addon provides `{{app-version}}` helper that allows you to show your curren
 
 The addon has flags to display parts of the version:
 
-* `{{app-version hideSha=true}} // => 2.0.1`
-* `{{app-version hideVersion=true}} // => <git SHA>`
+* `{{app-version versionOnly=true}} // => 2.0.1`
+* `{{app-version versionOnly=true showExtended=true}} // => 2.0.1-alpha.1`
+* `{{app-version shaOnly=true}} // => <git SHA>`
 
 Flags are `false` by default.
 

--- a/addon/utils/regexp.js
+++ b/addon/utils/regexp.js
@@ -1,2 +1,3 @@
-export const versionRegExp = /\d[.]\d[.]\d/;
-export const shaRegExp = /[a-z\d]{8}/;
+export const versionRegExp = /\d+[.]\d+[.]\d+/;	// Match any number of 3 sections of digits separated by .
+export const versionExtendedRegExp = /\d+[.]\d+[.]\d+-[a-z]*([.]\d+)?/;	// Match the above but also hyphen followed by any number of lowercase letters, then optionally period and digits
+export const shaRegExp = /[a-z\d]{8}$/;	// Match 8 lowercase letters and digits, at the end of the string only (to avoid matching with version extended part)

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -2,38 +2,31 @@ import { helper } from '@ember/component/helper';
 import config from '../config/environment';
 import { shaRegExp, versionRegExp, versionExtendedRegExp } from 'ember-cli-app-version/utils/regexp';
 
-const {
-  APP: {
-    version
+export function appVersion(_, hash = {}) {
+  const version = config.APP.version;
+  // e.g. 1.0.0-alpha.1+4jds75hf
+
+  // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
+  let versionOnly = hash.versionOnly || hash.hideSha;
+  let shaOnly = hash.shaOnly || hash.hideVersion;
+
+  let match = null;
+
+  if (versionOnly) {
+    if (hash.showExtended) {
+      match = version.match(versionExtendedRegExp); // 1.0.0-alpha.1
+    }
+    // Fallback to just version
+    if (!match) {
+      match = version.match(versionRegExp); // 1.0.0
+    }
   }
-} = config;
 
-export function makeHelper(version) {
-  return function appVersion(_, hash = {}) {
-    // e.g. 1.0.0-alpha.1+4jds75hf
+  if (shaOnly) {
+    match = version.match(shaRegExp); // 4jds75hf
+  }
 
-    // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
-    let versionOnly = hash.versionOnly || hash.hideSha;
-    let shaOnly = hash.shaOnly || hash.hideVersion;
-
-    let match = null;
-
-    if (versionOnly) {
-      if (hash.showExtended) {
-        match = version.match(versionExtendedRegExp); // 1.0.0-alpha.1
-      }
-      // Fallback to just version
-      if (!match) {
-        match = version.match(versionRegExp); // 1.0.0
-      }
-    }
-
-    if (shaOnly) {
-      match = version.match(shaRegExp); // 4jds75hf
-    }
-
-    return match?match[0]:version;
-  };
+  return match ? match[0] : version;
 }
 
 export default helper(appVersion);

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -21,7 +21,9 @@ export function makeHelper(version) {
     if (versionOnly) {
       if (hash.showExtended) {
         match = version.match(versionExtendedRegExp); // 1.0.0-alpha.1
-      } else {
+      }
+      // Fallback to just version
+      if (!match) {
         match = version.match(versionRegExp); // 1.0.0
       }
     }

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 import config from '../config/environment';
-import { shaRegExp, versionRegExp } from 'ember-cli-app-version/utils/regexp';
+import { shaRegExp, versionRegExp, versionExtendedRegExp } from 'ember-cli-app-version/utils/regexp';
 
 const {
   APP: {
@@ -9,14 +9,24 @@ const {
 } = config;
 
 export function appVersion(_, hash = {}) {
-  if (hash.hideSha) {
-    return version.match(versionRegExp)[0];
+  // e.g. 1.0.0-alpha.1+4jds75hf
+  
+  // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
+  hash.versionOnly = hash.versionOnly || hash.hideSha;
+  hash.shaOnly = hash.shaOnly || hash.hideVersion;
+  
+  if (hash.versionOnly) {
+    if (hash.showExtended) {
+      return version.match(versionExtendedRegExp)[0]; // 1.0.0-alpha.1
+    } else {
+      return version.match(versionRegExp)[0]; // 1.0.0
+    }
   }
-
-  if (hash.hideVersion) {
-    return version.match(shaRegExp)[0];
+  
+  if (hash.shaOnly) {
+    return version.match(shaRegExp)[0]; // 4jds75hf
   }
-
+  
   return version;
 }
 

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -13,12 +13,12 @@ export function makeHelper(version) {
     // e.g. 1.0.0-alpha.1+4jds75hf
 
     // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
-    hash.versionOnly = hash.versionOnly || hash.hideSha;
-    hash.shaOnly = hash.shaOnly || hash.hideVersion;
+    let versionOnly = hash.versionOnly || hash.hideSha;
+    let shaOnly = hash.shaOnly || hash.hideVersion;
 
     let match = null;
 
-    if (hash.versionOnly) {
+    if (versionOnly) {
       if (hash.showExtended) {
         match = version.match(versionExtendedRegExp); // 1.0.0-alpha.1
       } else {
@@ -26,7 +26,7 @@ export function makeHelper(version) {
       }
     }
 
-    if (hash.shaOnly) {
+    if (shaOnly) {
       match = version.match(shaRegExp); // 4jds75hf
     }
 

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -8,26 +8,28 @@ const {
   }
 } = config;
 
-export function appVersion(_, hash = {}) {
-  // e.g. 1.0.0-alpha.1+4jds75hf
-  
-  // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
-  hash.versionOnly = hash.versionOnly || hash.hideSha;
-  hash.shaOnly = hash.shaOnly || hash.hideVersion;
-  
-  if (hash.versionOnly) {
-    if (hash.showExtended) {
-      return version.match(versionExtendedRegExp)[0]; // 1.0.0-alpha.1
-    } else {
-      return version.match(versionRegExp)[0]; // 1.0.0
+export function makeHelper(version) {
+  return function appVersion(_, hash = {}) {
+    // e.g. 1.0.0-alpha.1+4jds75hf
+
+    // Allow use of 'hideSha' and 'hideVersion' For backwards compatibility
+    hash.versionOnly = hash.versionOnly || hash.hideSha;
+    hash.shaOnly = hash.shaOnly || hash.hideVersion;
+
+    if (hash.versionOnly) {
+      if (hash.showExtended) {
+        return version.match(versionExtendedRegExp)[0]; // 1.0.0-alpha.1
+      } else {
+        return version.match(versionRegExp)[0]; // 1.0.0
+      }
     }
-  }
-  
-  if (hash.shaOnly) {
-    return version.match(shaRegExp)[0]; // 4jds75hf
-  }
-  
-  return version;
+
+    if (hash.shaOnly) {
+      return version.match(shaRegExp)[0]; // 4jds75hf
+    }
+
+    return version;
+  };
 }
 
 export default helper(appVersion);

--- a/app/helpers/app-version.js
+++ b/app/helpers/app-version.js
@@ -16,19 +16,21 @@ export function makeHelper(version) {
     hash.versionOnly = hash.versionOnly || hash.hideSha;
     hash.shaOnly = hash.shaOnly || hash.hideVersion;
 
+    let match = null;
+
     if (hash.versionOnly) {
       if (hash.showExtended) {
-        return version.match(versionExtendedRegExp)[0]; // 1.0.0-alpha.1
+        match = version.match(versionExtendedRegExp); // 1.0.0-alpha.1
       } else {
-        return version.match(versionRegExp)[0]; // 1.0.0
+        match = version.match(versionRegExp); // 1.0.0
       }
     }
 
     if (hash.shaOnly) {
-      return version.match(shaRegExp)[0]; // 4jds75hf
+      match = version.match(shaRegExp); // 4jds75hf
     }
 
-    return version;
+    return match?match[0]:version;
   };
 }
 

--- a/tests/integration/helpers/app-version-test.js
+++ b/tests/integration/helpers/app-version-test.js
@@ -1,25 +1,57 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { shaRegExp, versionRegExp } from 'ember-cli-app-version/utils/regexp';
+import { shaRegExp, versionRegExp, versionExtendedRegExp } from 'ember-cli-app-version/utils/regexp';
 
 moduleForComponent('Integration | Helper | {{app-version}}', {
   integration: true
 });
 
-test('it displays only app version', function(assert) {
+test('it displays only app version (backwards compatible)', function(assert) {
   assert.expect(2);
 
   this.render(hbs`{{app-version hideSha=true}}`);
 
   assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
+  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
   assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
 });
 
-test('it displays only git sha', function(assert) {
+test('it displays only app version', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`{{app-version versionOnly=true}}`);
+
+  assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
+  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
+  assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
+});
+
+test('it displays only app version extended', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`{{app-version versionOnly=true showExtended=true}}`);
+
+  assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
+  assert.ok(this.$().text().match(versionExtendedRegExp), 'Displays version extended.');
+  assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
+});
+
+test('it displays only git sha (backwards compatible)', function(assert) {
   assert.expect(2);
 
   this.render(hbs`{{app-version hideVersion=true}}`);
 
   assert.ok(this.$().text().match(shaRegExp), 'Displays git sha.');
+  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
+  assert.ok(!this.$().text().match(versionRegExp), 'Does not display version.');
+});
+
+test('it displays only git sha', function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`{{app-version shaOnly=true}}`);
+
+  assert.ok(this.$().text().match(shaRegExp), 'Displays git sha.');
+  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
   assert.ok(!this.$().text().match(versionRegExp), 'Does not display version.');
 });

--- a/tests/integration/helpers/app-version-test.js
+++ b/tests/integration/helpers/app-version-test.js
@@ -1,57 +1,54 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { shaRegExp, versionRegExp, versionExtendedRegExp } from 'ember-cli-app-version/utils/regexp';
 
 moduleForComponent('Integration | Helper | {{app-version}}', {
   integration: true
 });
 
+test('it displays entire version', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{app-version}}`);
+
+  assert.ok(this.$().text(), 'Version not empty');
+});
+
 test('it displays only app version (backwards compatible)', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`{{app-version hideSha=true}}`);
 
-  assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
-  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
-  assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
+  assert.ok(this.$().text(), 'Version not empty');
 });
 
 test('it displays only app version', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`{{app-version versionOnly=true}}`);
 
-  assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
-  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
-  assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
+  assert.ok(this.$().text(), 'Version not empty');
 });
 
 test('it displays only app version extended', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`{{app-version versionOnly=true showExtended=true}}`);
 
-  assert.ok(this.$().text().match(versionRegExp), 'Displays version.');
-  assert.ok(this.$().text().match(versionExtendedRegExp), 'Displays version extended.');
-  assert.ok(!this.$().text().match(shaRegExp), 'Does not display git sha.');
+  assert.ok(this.$().text(), 'Version not empty');
 });
 
 test('it displays only git sha (backwards compatible)', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`{{app-version hideVersion=true}}`);
 
-  assert.ok(this.$().text().match(shaRegExp), 'Displays git sha.');
-  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
-  assert.ok(!this.$().text().match(versionRegExp), 'Does not display version.');
+  assert.ok(this.$().text(), 'Version not empty');
 });
 
 test('it displays only git sha', function(assert) {
-  assert.expect(2);
+  assert.expect(1);
 
   this.render(hbs`{{app-version shaOnly=true}}`);
 
-  assert.ok(this.$().text().match(shaRegExp), 'Displays git sha.');
-  assert.ok(!this.$().text().match(versionExtendedRegExp), 'Does not display version extended.');
-  assert.ok(!this.$().text().match(versionRegExp), 'Does not display version.');
+  assert.ok(this.$().text(), 'Version not empty');
 });

--- a/tests/unit/helpers/app-version-test.js
+++ b/tests/unit/helpers/app-version-test.js
@@ -1,12 +1,11 @@
-import { appVersion } from 'dummy/helpers/app-version';
+import { makeHelper } from 'dummy/helpers/app-version';
 import { module, test } from 'qunit';
-import config from 'dummy/config/environment';
 
-const {
-  APP: {
-    version
-  }
-} = config;
+const versionOnlyString = '10.20.3';
+const extendedTagOnlyString = 'alpha.15';
+const shaOnlyString = 'deadb33f';
+const versionString = versionOnlyString+'-'+extendedTagOnlyString+'+'+shaOnlyString;
+const appVersion = makeHelper(versionString);
 
 module('Unit | Helper | app version');
 
@@ -15,21 +14,45 @@ test('it returns app version', function(assert) {
 
   let result = appVersion();
 
-  assert.equal(result, version, 'Returns app version.');
+  assert.equal(result, versionString, 'Returns app version.');
+});
+
+test('it returns only app version (backwards compatible)', function(assert) {
+  assert.expect(1);
+
+  let result = appVersion([], { hideSha: true });
+
+  assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
 });
 
 test('it returns only app version', function(assert) {
   assert.expect(1);
 
-  let result = appVersion([], { hideSha: true });
+  let result = appVersion([], { versionOnly: true });
 
-  assert.equal(result, version.split('+')[0], 'Returns app version without git sha.');
+  assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
+});
+
+test('it returns only app version extended', function(assert) {
+  assert.expect(1);
+
+  let result = appVersion([], { versionOnly: true, showExtended: true });
+
+  assert.equal(result, versionOnlyString+'-'+extendedTagOnlyString, 'Returns app version extended without git sha.');
+});
+
+test('it returns only git sha (backwards compatible)', function(assert) {
+  assert.expect(1);
+
+  let result = appVersion([], { hideVersion: true });
+
+  assert.equal(result, shaOnlyString, 'Returns git sha without app version.');
 });
 
 test('it returns only git sha', function(assert) {
   assert.expect(1);
 
-  let result = appVersion([], { hideVersion: true });
+  let result = appVersion([], { shaOnly: true });
 
-  assert.equal(result, version.split('+')[1], 'Returns git sha without app version.');
+  assert.equal(result, shaOnlyString, 'Returns git sha without app version.');
 });

--- a/tests/unit/helpers/app-version-test.js
+++ b/tests/unit/helpers/app-version-test.js
@@ -4,8 +4,12 @@ import { module, test } from 'qunit';
 const versionOnlyString = '10.20.3';
 const extendedTagOnlyString = 'alpha.15';
 const shaOnlyString = 'deadb33f';
+
 const versionString = versionOnlyString+'-'+extendedTagOnlyString+'+'+shaOnlyString;
 const appVersion = makeHelper(versionString);
+
+const standardVersionString = versionOnlyString+'+'+shaOnlyString;
+const standardAppVersion = makeHelper(standardVersionString);
 
 module('Unit | Helper | app version');
 
@@ -39,6 +43,14 @@ test('it returns only app version extended', function(assert) {
   let result = appVersion([], { versionOnly: true, showExtended: true });
 
   assert.equal(result, versionOnlyString+'-'+extendedTagOnlyString, 'Returns app version extended without git sha.');
+});
+
+test('it returns only app version (falls back when no extended)', function(assert) {
+  assert.expect(1);
+
+  let result = standardAppVersion([], { versionOnly: true, showExtended: true });
+
+  assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
 });
 
 test('it returns only git sha (backwards compatible)', function(assert) {

--- a/tests/unit/helpers/app-version-test.js
+++ b/tests/unit/helpers/app-version-test.js
@@ -1,4 +1,5 @@
-import { makeHelper } from 'dummy/helpers/app-version';
+import { appVersion } from 'dummy/helpers/app-version';
+import config from 'dummy/config/environment';
 import { module, test } from 'qunit';
 
 const versionOnlyString = '10.20.3';
@@ -6,24 +7,26 @@ const extendedTagOnlyString = 'alpha.15';
 const shaOnlyString = 'deadb33f';
 
 const versionString = versionOnlyString+'-'+extendedTagOnlyString+'+'+shaOnlyString;
-const appVersion = makeHelper(versionString);
-
 const standardVersionString = versionOnlyString+'+'+shaOnlyString;
-const standardAppVersion = makeHelper(standardVersionString);
+const oldVersion = config.APP.version;
 
-module('Unit | Helper | app version');
+module('Unit | Helper | app version', {
+  afterEach() {
+    config.APP.version = oldVersion;
+  }
+});
 
 test('it returns app version', function(assert) {
   assert.expect(1);
+  config.APP.version = versionString;
 
-  let result = appVersion();
-
-  assert.equal(result, versionString, 'Returns app version.');
+  assert.equal(appVersion(), versionString, 'Returns app version.');
 });
 
 test('it returns only app version (backwards compatible)', function(assert) {
   assert.expect(1);
 
+  config.APP.version = versionString;
   let result = appVersion([], { hideSha: true });
 
   assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
@@ -32,6 +35,7 @@ test('it returns only app version (backwards compatible)', function(assert) {
 test('it returns only app version', function(assert) {
   assert.expect(1);
 
+  config.APP.version = versionString;
   let result = appVersion([], { versionOnly: true });
 
   assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
@@ -40,6 +44,7 @@ test('it returns only app version', function(assert) {
 test('it returns only app version extended', function(assert) {
   assert.expect(1);
 
+  config.APP.version = versionString;
   let result = appVersion([], { versionOnly: true, showExtended: true });
 
   assert.equal(result, versionOnlyString+'-'+extendedTagOnlyString, 'Returns app version extended without git sha.');
@@ -48,7 +53,8 @@ test('it returns only app version extended', function(assert) {
 test('it returns only app version (falls back when no extended)', function(assert) {
   assert.expect(1);
 
-  let result = standardAppVersion([], { versionOnly: true, showExtended: true });
+  config.APP.version = standardVersionString;
+  let result = appVersion([], { versionOnly: true, showExtended: true });
 
   assert.equal(result, versionOnlyString, 'Returns app version without git sha.');
 });
@@ -56,6 +62,7 @@ test('it returns only app version (falls back when no extended)', function(asser
 test('it returns only git sha (backwards compatible)', function(assert) {
   assert.expect(1);
 
+  config.APP.version = versionString;
   let result = appVersion([], { hideVersion: true });
 
   assert.equal(result, shaOnlyString, 'Returns git sha without app version.');
@@ -64,6 +71,7 @@ test('it returns only git sha (backwards compatible)', function(assert) {
 test('it returns only git sha', function(assert) {
   assert.expect(1);
 
+  config.APP.version = versionString;
   let result = appVersion([], { shaOnly: true });
 
   assert.equal(result, shaOnlyString, 'Returns git sha without app version.');

--- a/tests/unit/utils/regexp-test.js
+++ b/tests/unit/utils/regexp-test.js
@@ -15,12 +15,12 @@ test('version reg ex matches expected strings', function(assert) {
 test('version extended reg ex matches expected strings', function(assert) {
   assert.expect(6);
 
-  assert.ok('2.0.1-alpha'.match(versionRegExp), 'Matches expected pattern.');
-  assert.ok('2.20.1-alpha.15'.match(versionRegExp), 'Matches expected pattern.');
-  assert.ok(!'1.1.1-alpha.'.match(versionRegExp), 'Does not match hanging period.');
-  assert.ok(!'1.1.1-alpha.abc'.match(versionRegExp), 'Does not match letters after extended tag period.');
-  assert.ok(!'a.b.c-alpha.15'.match(versionRegExp), 'Does not match letters.');
-  assert.ok(!'git12sha'.match(versionRegExp), 'Does not match sha.');
+  assert.ok('2.0.1-alpha'.match(versionExtendedRegExp), 'Matches expected pattern.');
+  assert.ok('2.20.1-alpha.15'.match(versionExtendedRegExp), 'Matches expected pattern.');
+  assert.ok(!'1.1.1-alpha.'.match(versionExtendedRegExp), 'Does not match hanging period.');
+  assert.ok(!'1.1.1-alpha.abc'.match(versionExtendedRegExp), 'Does not match letters after extended tag period.');
+  assert.ok(!'a.b.c-alpha.15'.match(versionExtendedRegExp), 'Does not match letters.');
+  assert.ok(!'git12sha'.match(versionExtendedRegExp), 'Does not match sha.');
 });
 
 test('git sha reg ex matches expected strings', function(assert) {

--- a/tests/unit/utils/regexp-test.js
+++ b/tests/unit/utils/regexp-test.js
@@ -1,19 +1,33 @@
 import { module, test } from 'qunit';
-import { shaRegExp, versionRegExp } from 'ember-cli-app-version/utils/regexp';
+import { shaRegExp, versionRegExp, versionExtendedRegExp } from 'ember-cli-app-version/utils/regexp';
 
 module('Unit | Utility | regexp');
 
 test('version reg ex matches expected strings', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   assert.ok('2.0.1'.match(versionRegExp), 'Matches expected pattern.');
+  assert.ok('2.20.1'.match(versionRegExp), 'Matches expected pattern.');
   assert.ok(!'a.b.c'.match(versionRegExp), 'Does not match letters.');
   assert.ok(!'git12sha'.match(versionRegExp), 'Does not match sha.');
 });
 
+test('version extended reg ex matches expected strings', function(assert) {
+  assert.expect(6);
+
+  assert.ok('2.0.1-alpha'.match(versionRegExp), 'Matches expected pattern.');
+  assert.ok('2.20.1-alpha.15'.match(versionRegExp), 'Matches expected pattern.');
+  assert.ok(!'1.1.1-alpha.'.match(versionRegExp), 'Does not match hanging period.');
+  assert.ok(!'1.1.1-alpha.abc'.match(versionRegExp), 'Does not match letters after extended tag period.');
+  assert.ok(!'a.b.c-alpha.15'.match(versionRegExp), 'Does not match letters.');
+  assert.ok(!'git12sha'.match(versionRegExp), 'Does not match sha.');
+});
+
 test('git sha reg ex matches expected strings', function(assert) {
-  assert.expect(2);
+  assert.expect(4);
 
   assert.ok('git12sha'.match(shaRegExp), 'Matches expected pattern.');
   assert.ok(!'2.0.1'.match(shaRegExp), 'Does not match version pattern.');
+  assert.ok(!'2.0.1-alpha.15'.match(shaRegExp), 'Does not match version extended pattern.');
+  assert.ok(!'2.0.1-alphaabc.15'.match(shaRegExp), 'Does not match version extended pattern (with 8 chars in tag name).');
 });

--- a/tests/unit/utils/regexp-test.js
+++ b/tests/unit/utils/regexp-test.js
@@ -13,12 +13,10 @@ test('version reg ex matches expected strings', function(assert) {
 });
 
 test('version extended reg ex matches expected strings', function(assert) {
-  assert.expect(6);
+  assert.expect(4);
 
   assert.ok('2.0.1-alpha'.match(versionExtendedRegExp), 'Matches expected pattern.');
   assert.ok('2.20.1-alpha.15'.match(versionExtendedRegExp), 'Matches expected pattern.');
-  assert.ok(!'1.1.1-alpha.'.match(versionExtendedRegExp), 'Does not match hanging period.');
-  assert.ok(!'1.1.1-alpha.abc'.match(versionExtendedRegExp), 'Does not match letters after extended tag period.');
   assert.ok(!'a.b.c-alpha.15'.match(versionExtendedRegExp), 'Does not match letters.');
   assert.ok(!'git12sha'.match(versionExtendedRegExp), 'Does not match sha.');
 });


### PR DESCRIPTION
New flags;
```handlebars
{{app-version versionOnly=true}} // => 2.0.1
{{app-version versionOnly=true showExtended=true}} // => 2.0.1-alpha.1
{{app-version shaOnly=true}} // => <git SHA>
```

Old flags `hideVersion` and `hideSha` still work, they're just changed into `shaOnly` and `versionOnly` respectively.

-----

Improved regex;
`versionRegExp` now matches any number of digits between periods (so versions like 1.20.0 will work)
`versionExtendedRegExp` now included, which matches version & the extended version tag
`shaRegExp` now only matches 8 chars /at the end/ of the version string, to stop it from matching with the extended tag (if the tag is 8 chars or longer, for example)