### PR TITLE
Makes version regexp more flexible

### DIFF
--- a/addon/utils/regexp.js
+++ b/addon/utils/regexp.js
@@ -1,2 +1,2 @@
-export const versionRegExp = /(\d+[.]?)+\d+/;
+export const versionRegExp = /(\d+[.])+\d+/;
 export const shaRegExp = /[a-z\d]{8}/;

--- a/addon/utils/regexp.js
+++ b/addon/utils/regexp.js
@@ -1,2 +1,2 @@
-export const versionRegExp = /\d[.]\d[.]\d/;
+export const versionRegExp = /(\d+[.]?)+\d+/;
 export const shaRegExp = /[a-z\d]{8}/;

--- a/tests/unit/utils/regexp-test.js
+++ b/tests/unit/utils/regexp-test.js
@@ -4,9 +4,12 @@ import { shaRegExp, versionRegExp } from 'ember-cli-app-version/utils/regexp';
 module('Unit | Utility | regexp');
 
 test('version reg ex matches expected strings', function(assert) {
-  assert.expect(3);
+  assert.expect(6);
 
   assert.ok('2.0.1'.match(versionRegExp), 'Matches expected pattern.');
+  assert.ok('2018.01.01.1500'.match(versionRegExp), 'Matches multiple dot separated groups of numbers.');
+  assert.ok(!'01'.match(versionRegExp), 'Does not match numbers without a dot.');
+  assert.ok(!'11.b.12'.match(versionRegExp), 'Does not match alternating numbers and letters.');
   assert.ok(!'a.b.c'.match(versionRegExp), 'Does not match letters.');
   assert.ok(!'git12sha'.match(versionRegExp), 'Does not match sha.');
 });


### PR DESCRIPTION
Hi, thanks for the ember addon!

I've got a setup where our CI server builds our ember app and instead of typical semantic versioning we use a datetime format like: `YYYY.MM.DD.HHMM` and at the moment `ember-cli-app-version` only allows for a single digit in each section.

Standard semantic versioning would also likely have double digit minor and patch versions like `1.0.13` which don't meet the current regexp criteria.

Cheers!