### PR TITLE
update regex to allow multi-digit version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This addon provides `{{app-version}}` helper that allows you to show your curren
 
 The addon has flags to display parts of the version:
 
-* `{{app-version hideSha=true}} // => 2.0.1`
+* `{{app-version hideSha=true}} // => 2.10.1`
 * `{{app-version hideVersion=true}} // => <git SHA>`
 
 Flags are `false` by default.

--- a/addon/utils/regexp.js
+++ b/addon/utils/regexp.js
@@ -1,2 +1,2 @@
-export const versionRegExp = /\d[.]\d[.]\d/;
+export const versionRegExp = /\d+[.]\d+[.]\d+/;
 export const shaRegExp = /[a-z\d]{8}/;


### PR DESCRIPTION
Fixes #62 , updated README to show a multi-digit version in example

NOTE: I was not able to get the tests to run, I think because I've removed PhantomJS? Was thinking that the package.json version number (if that is what the tests test against) could have one of the version with a multi-digit version to test this case. 