### PR TITLE
Drop support for Node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "index.js"
   ],
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "author": "Taras Mankovski <taras@embersherpa.com>",
   "license": "MIT",


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli-app-version/pull/69 dropped Node 4 from the CI config, but we never actually officially dropped support for it. This PR changes the compatibility declaration in the `package.json` file accordingly and will have to result in a major version bump as this is a breaking change.

/cc @luxferresum @stefanpenner 