### PR TITLE
Remove `config/environment.js` entry from `files` in `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "files": [
     "addon/",
     "app/",
-    "config/environment.js",
     "index.js"
   ],
   "scripts": {


### PR DESCRIPTION
This addon doesn't have (nor need) this file anymore.