### PR TITLE
Remove use of `@ember/string` to avoid deprecation

### DIFF
--- a/addon/initializer-factory.js
+++ b/addon/initializer-factory.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import { classify } from '@ember/string';
 
 const { libraries } = Ember;
 
@@ -8,8 +7,7 @@ export default function initializerFactory(name, version) {
 
   return function () {
     if (!registered && name && version) {
-      let appName = classify(name);
-      libraries.register(appName, version);
+      libraries.register(name, version);
       registered = true;
     }
   };


### PR DESCRIPTION
Importing from `@ember/string` in Ember v4.10, without having the `@ember/string` addon installed is deprecated.
Normally, the current proposed solution would be to add `@ember/string` as a peer dependency and have the consuming app bring in the addon. However, in this case, I think we can just remove the use of `@ember/string` all together. This will now log the app's name as is, untransformed.