### PR TITLE
Add a workflow for publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: auto-dist-tag
+        run: npx auto-dist-tag@1 --write
+
+      - name: publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: auto-dist-tag
-        run: npx auto-dist-tag@1 --write
+        run: npx auto-dist-tag --write
 
       - name: publish to npm
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
     "github": {
       "release": true,
       "tokenRef": "GITHUB_AUTH"
+    },
+    "npm": {
+      "publish": false
     }
   }
 }


### PR DESCRIPTION
I have added NPM_AUTH_TOKEN to the secrets. It is a granular access token under my account. It will expire in a year. 