### PR TITLE
Support for ember 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+    "ember-source": "^3.28.0 || >= 4.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Full disclosure, looked very little into this.  I am new to ember and just having issues going through the quick start guide, so spent some time trying to figure out why.

With ember-cli 5 [getting released as latest](https://www.npmjs.com/package/ember-cli?activeTab=versions) the [quick start guide](https://guides.emberjs.com/release/getting-started/quick-start/) is failing on `ember new ember-quickstart --lang en`

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: ember-quickstart@0.0.0
npm ERR! Found: ember-source@5.0.0
npm ERR! node_modules/ember-source
npm ERR!   dev ember-source@"~5.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer ember-source@"^3.28.0 || ^4.0.0" from ember-cli-app-version@6.0.0
npm ERR! node_modules/ember-cli-app-version
npm ERR!   dev ember-cli-app-version@"^6.0.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```