### PR TITLE
Do not use Ember Barrel file import

### DIFF
--- a/addon/initializer-factory.js
+++ b/addon/initializer-factory.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { libraries } = Ember;
+import { libraries } from '@ember/-internals/metal';
 
 export default function initializerFactory(name, version) {
   let registered = false;


### PR DESCRIPTION
😬 

Alternatively we could promote this to a more public module.

in https://github.com/emberjs/rfcs/pull/1015 , I proposed maybe something like `@ember/user-meta`. but it would require library authors to use macros to support broad ember-source versions, as prior to 5.10, those library authors would still have to use `@ember/-internals/metal` or `'ember'` 